### PR TITLE
feat(attendees): wire Attendees page to real backend endpoint

### DIFF
--- a/frontend/eventconnect-web/src/pages/Attendees.tsx
+++ b/frontend/eventconnect-web/src/pages/Attendees.tsx
@@ -1,12 +1,139 @@
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { mockEvents } from "@/data/mockEvents";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Users, AlertTriangle } from "lucide-react";
+
+type AttendeeStatus = "going" | "interested" | "not_going";
+
+interface ApiAttendee {
+  event_id: string;
+  user_id: string | number;
+  display_name: string | null;
+  status: AttendeeStatus;
+  joined_at: string;
+}
+
+interface AttendeesResponse {
+  event_id: string;
+  attendee_count: number;
+  attendees: ApiAttendee[];
+}
+
+type LoadState = "loading" | "ready" | "empty" | "not-found" | "error";
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function statusLabel(status: AttendeeStatus): string {
+  if (status === "going") return "Going";
+  if (status === "interested") return "Interested";
+  return "Not going";
+}
 
 export default function Attendees() {
   const { id } = useParams();
-  const event = mockEvents.find((e) => e.id === id);
+  const [attendees, setAttendees] = useState<ApiAttendee[]>([]);
+  const [attendeeCount, setAttendeeCount] = useState(0);
+  const [state, setState] = useState<LoadState>("loading");
 
-  if (!event) {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchAttendees() {
+      if (!id) {
+        setState("not-found");
+        return;
+      }
+
+      try {
+        const res = await fetch(`/events/${id}/attendees`);
+
+        if (res.status === 404) {
+          if (!cancelled) setState("not-found");
+          return;
+        }
+
+        if (!res.ok) {
+          if (!cancelled) setState("error");
+          return;
+        }
+
+        const data: AttendeesResponse = await res.json();
+        if (cancelled) return;
+
+        const list = Array.isArray(data.attendees) ? data.attendees : [];
+        setAttendees(list);
+        setAttendeeCount(
+          typeof data.attendee_count === "number"
+            ? data.attendee_count
+            : list.length
+        );
+        setState(list.length === 0 ? "empty" : "ready");
+      } catch (err) {
+        console.error("Error fetching attendees:", err);
+        if (!cancelled) setState("error");
+      }
+    }
+
+    fetchAttendees();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const header = (
+    <div className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-xl">
+      <div className="container flex h-16 items-center gap-4">
+        <Link
+          to={`/events/${id}`}
+          aria-label="Back to event"
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-sm font-semibold text-foreground">Attendees</h1>
+          <p className="text-xs text-muted-foreground">
+            {state === "ready" || state === "empty"
+              ? `${attendeeCount} ${attendeeCount === 1 ? "person" : "people"} responded`
+              : "Loading\u2026"}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (state === "loading") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div role="status" aria-live="polite" className="container py-6">
+          <p className="sr-only">Loading attendees</p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                data-testid="attendee-skeleton"
+                className="flex animate-pulse items-center gap-3 rounded-xl border border-border bg-card p-4"
+              >
+                <div className="h-12 w-12 rounded-full bg-secondary" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-2/3 rounded bg-secondary" />
+                  <div className="h-2 w-1/3 rounded bg-secondary" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "not-found") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <p className="text-muted-foreground">Event not found</p>
@@ -14,33 +141,76 @@ export default function Attendees() {
     );
   }
 
-  return (
-    <div className="min-h-screen bg-background">
-      <div className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-xl">
-        <div className="container flex h-16 items-center gap-4">
-          <Link to={`/events/${id}`} className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors">
-            <ArrowLeft className="h-5 w-5" />
-          </Link>
-          <div>
-            <h1 className="text-sm font-semibold text-foreground">Attendees</h1>
-            <p className="text-xs text-muted-foreground">{event.title}</p>
+  if (state === "error") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div className="container py-10">
+          <div
+            role="alert"
+            className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-destructive/30 bg-destructive/10 p-6 text-center text-destructive"
+          >
+            <AlertTriangle className="mb-2 h-6 w-6" />
+            <p className="font-semibold">Could not load attendees</p>
+            <p className="mt-1 text-sm">
+              Something went wrong talking to the server. Please refresh the
+              page or try again later.
+            </p>
           </div>
         </div>
       </div>
+    );
+  }
 
-      <div className="container py-6">
-        <p className="mb-4 text-sm text-muted-foreground">{event.attendees.length} people attending</p>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {event.attendees.map((a) => (
-            <div key={a.id} className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover">
-              <img src={a.avatar} alt={a.name} className="h-12 w-12 rounded-full object-cover" />
-              <div>
-                <p className="font-medium text-foreground">{a.name}</p>
-                <p className="text-xs text-muted-foreground">Attending</p>
-              </div>
-            </div>
-          ))}
+  if (state === "empty") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div className="container py-10">
+          <div className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-border bg-card p-8 text-center">
+            <Users className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="font-semibold text-foreground">
+              No one has responded yet
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Be the first to RSVP and attendees will show up here.
+            </p>
+          </div>
         </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {header}
+      <div className="container py-6">
+        <p className="mb-4 text-sm text-muted-foreground">
+          {attendeeCount} {attendeeCount === 1 ? "person" : "people"} responded
+        </p>
+        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {attendees.map((a) => (
+            <li
+              key={`${a.event_id}-${a.user_id}`}
+              className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover"
+            >
+              <div
+                aria-hidden="true"
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
+              >
+                {getInitials(a.display_name)}
+              </div>
+              <div className="min-w-0">
+                <p className="truncate font-medium text-foreground">
+                  {a.display_name || "Anonymous"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {statusLabel(a.status)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/frontend/eventconnect-web/src/test/Attendees.test.tsx
+++ b/frontend/eventconnect-web/src/test/Attendees.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Attendees from "../pages/Attendees";
+
+// Mock global fetch, matching the pattern used in RSVPButton.test.tsx
+global.fetch = vi.fn();
+
+function renderAtEvent(eventId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${eventId}/attendees`]}>
+      <Routes>
+        <Route path="/events/:id/attendees" element={<Attendees />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const buildOkResponse = (attendees: any[], count?: number) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    event_id: "evt-1",
+    attendee_count: count ?? attendees.length,
+    attendees,
+  }),
+});
+
+describe("Attendees page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the loading skeleton while fetching", async () => {
+    // Return a slow-resolving response so we can see the loading state
+    (fetch as any).mockImplementationOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(buildOkResponse([])), 100)
+        )
+    );
+
+    renderAtEvent("evt-1");
+
+    expect(screen.getAllByTestId("attendee-skeleton").length).toBeGreaterThan(0);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders a real attendee list returned by the backend", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 1,
+          display_name: "Sofia Chen",
+          status: "going",
+          joined_at: "2026-04-01T00:00:00Z",
+        },
+        {
+          event_id: "evt-1",
+          user_id: 2,
+          display_name: "Marcus Johnson",
+          status: "interested",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    expect(screen.getByText("Going")).toBeInTheDocument();
+    expect(screen.getByText("Interested")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("/events/evt-1/attendees");
+  });
+
+  it("renders initials from the display name when no avatar is returned", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 9,
+          display_name: "Aisha Patel",
+          status: "going",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Aisha Patel")).toBeInTheDocument();
+    });
+    expect(screen.getByText("AP")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Anonymous' when display_name is null", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 7,
+          display_name: null,
+          status: "going",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the empty state when the event has no attendees", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse([]));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no one has responded yet/i)
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryAllByTestId("attendee-skeleton").length).toBe(0);
+  });
+
+  it("shows a not-found state when the backend returns 404", async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "Event not found" }),
+    });
+
+    renderAtEvent("evt-missing");
+
+    await waitFor(() => {
+      expect(screen.getByText(/event not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error alert when the backend returns 500", async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Internal server error" }),
+    });
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /could not load attendees/i
+      );
+    });
+  });
+
+  it("shows an error alert when fetch rejects (network failure)", async () => {
+    (fetch as any).mockRejectedValueOnce(new Error("network down"));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Replace mockEvents lookup with a live fetch against GET /events/:id/attendees. Adds loading/empty/error/404 states, falls back to "Anonymous" when display_name is null, and derives avatar initials from the display name since the backend doesn't return avatar URLs yet.

Adds 8 integration tests covering every render state plus the initials rendering and anonymous fallback.

Fixes the bug where every event's Attendees page showed the same six mock Unsplash avatars regardless of the URL parameter.