### PR TITLE
feat(attendees): add client-side search filter and status chip filters

### DIFF
--- a/frontend/eventconnect-web/src/pages/Attendees.tsx
+++ b/frontend/eventconnect-web/src/pages/Attendees.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Users, AlertTriangle } from "lucide-react";
+import { ArrowLeft, Users, AlertTriangle, Search, X } from "lucide-react";
 
 type AttendeeStatus = "going" | "interested" | "not_going";
+type StatusFilter = "all" | AttendeeStatus;
 
 interface ApiAttendee {
   event_id: string;
@@ -34,11 +35,26 @@ function statusLabel(status: AttendeeStatus): string {
   return "Not going";
 }
 
+// Label used in the filter chip UI — "Not going" is ungainly as a chip, so we
+// surface it as "Declined" there (matches the Profile stats card copy).
+function chipLabel(status: StatusFilter): string {
+  if (status === "all") return "All";
+  if (status === "going") return "Going";
+  if (status === "interested") return "Interested";
+  return "Declined";
+}
+
+const STATUS_CHIPS: StatusFilter[] = ["all", "going", "interested", "not_going"];
+
 export default function Attendees() {
   const { id } = useParams();
   const [attendees, setAttendees] = useState<ApiAttendee[]>([]);
   const [attendeeCount, setAttendeeCount] = useState(0);
   const [state, setState] = useState<LoadState>("loading");
+
+  // Polish UI state — client-side only.
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 
   useEffect(() => {
     let cancelled = false;
@@ -84,6 +100,34 @@ export default function Attendees() {
       cancelled = true;
     };
   }, [id]);
+
+  // Per-status counts computed once per attendees change so the chips can
+  // show "(n)" without re-walking the list on every render.
+  const statusCounts = useMemo(() => {
+    const counts = { going: 0, interested: 0, not_going: 0 };
+    for (const a of attendees) {
+      if (a.status in counts) counts[a.status] += 1;
+    }
+    return counts;
+  }, [attendees]);
+
+  const filteredAttendees = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return attendees.filter((a) => {
+      if (statusFilter !== "all" && a.status !== statusFilter) return false;
+      if (!q) return true;
+      // Match against the rendered name so users can search "Anonymous" and
+      // find rows whose display_name is null.
+      const name = (a.display_name || "Anonymous").toLowerCase();
+      return name.includes(q);
+    });
+  }, [attendees, query, statusFilter]);
+
+  const filtersActive = query.trim() !== "" || statusFilter !== "all";
+  const clearFilters = () => {
+    setQuery("");
+    setStatusFilter("all");
+  };
 
   const header = (
     <div className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-xl">
@@ -181,6 +225,7 @@ export default function Attendees() {
     );
   }
 
+  // ---------- Ready ----------
   return (
     <div className="min-h-screen bg-background">
       {header}
@@ -188,29 +233,104 @@ export default function Attendees() {
         <p className="mb-4 text-sm text-muted-foreground">
           {attendeeCount} {attendeeCount === 1 ? "person" : "people"} responded
         </p>
-        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {attendees.map((a) => (
-            <li
-              key={`${a.event_id}-${a.user_id}`}
-              className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover"
-            >
-              <div
-                aria-hidden="true"
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
+
+        {/* Filter bar */}
+        <div
+          data-testid="attendees-filter-bar"
+          className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center"
+        >
+          <div className="relative flex-1">
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search attendees by name"
+              placeholder="Search attendees"
+              className="w-full rounded-xl border border-border bg-card py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
+          </div>
+
+          <div
+            role="group"
+            aria-label="Filter by RSVP status"
+            className="flex flex-wrap gap-2"
+          >
+            {STATUS_CHIPS.map((s) => {
+              const active = statusFilter === s;
+              const count =
+                s === "all"
+                  ? attendees.length
+                  : statusCounts[s as AttendeeStatus];
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setStatusFilter(s)}
+                  aria-pressed={active}
+                  data-testid={`chip-${s}`}
+                  className={
+                    "rounded-full border px-3 py-1 text-xs font-medium transition-colors " +
+                    (active
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-card text-muted-foreground hover:bg-surface-hover hover:text-foreground")
+                  }
+                >
+                  {chipLabel(s)} ({count})
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {filteredAttendees.length === 0 ? (
+          <div
+            data-testid="attendees-no-results"
+            className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-border bg-card p-8 text-center"
+          >
+            <Users className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="font-semibold text-foreground">No attendees match</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Try a different search or clear the filters to see everyone.
+            </p>
+            {filtersActive && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="mt-4 inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
               >
-                {getInitials(a.display_name)}
-              </div>
-              <div className="min-w-0">
-                <p className="truncate font-medium text-foreground">
-                  {a.display_name || "Anonymous"}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {statusLabel(a.status)}
-                </p>
-              </div>
-            </li>
-          ))}
-        </ul>
+                <X className="h-3 w-3" /> Clear filters
+              </button>
+            )}
+          </div>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredAttendees.map((a) => (
+              <li
+                key={`${a.event_id}-${a.user_id}`}
+                className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover"
+              >
+                <div
+                  aria-hidden="true"
+                  className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
+                >
+                  {getInitials(a.display_name)}
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate font-medium text-foreground">
+                    {a.display_name || "Anonymous"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {statusLabel(a.status)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/frontend/eventconnect-web/src/pages/Attendees.tsx
+++ b/frontend/eventconnect-web/src/pages/Attendees.tsx
@@ -1,12 +1,139 @@
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { mockEvents } from "@/data/mockEvents";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Users, AlertTriangle } from "lucide-react";
+
+type AttendeeStatus = "going" | "interested" | "not_going";
+
+interface ApiAttendee {
+  event_id: string;
+  user_id: string | number;
+  display_name: string | null;
+  status: AttendeeStatus;
+  joined_at: string;
+}
+
+interface AttendeesResponse {
+  event_id: string;
+  attendee_count: number;
+  attendees: ApiAttendee[];
+}
+
+type LoadState = "loading" | "ready" | "empty" | "not-found" | "error";
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function statusLabel(status: AttendeeStatus): string {
+  if (status === "going") return "Going";
+  if (status === "interested") return "Interested";
+  return "Not going";
+}
 
 export default function Attendees() {
   const { id } = useParams();
-  const event = mockEvents.find((e) => e.id === id);
+  const [attendees, setAttendees] = useState<ApiAttendee[]>([]);
+  const [attendeeCount, setAttendeeCount] = useState(0);
+  const [state, setState] = useState<LoadState>("loading");
 
-  if (!event) {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchAttendees() {
+      if (!id) {
+        setState("not-found");
+        return;
+      }
+
+      try {
+        const res = await fetch(`/events/${id}/attendees`);
+
+        if (res.status === 404) {
+          if (!cancelled) setState("not-found");
+          return;
+        }
+
+        if (!res.ok) {
+          if (!cancelled) setState("error");
+          return;
+        }
+
+        const data: AttendeesResponse = await res.json();
+        if (cancelled) return;
+
+        const list = Array.isArray(data.attendees) ? data.attendees : [];
+        setAttendees(list);
+        setAttendeeCount(
+          typeof data.attendee_count === "number"
+            ? data.attendee_count
+            : list.length
+        );
+        setState(list.length === 0 ? "empty" : "ready");
+      } catch (err) {
+        console.error("Error fetching attendees:", err);
+        if (!cancelled) setState("error");
+      }
+    }
+
+    fetchAttendees();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const header = (
+    <div className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-xl">
+      <div className="container flex h-16 items-center gap-4">
+        <Link
+          to={`/events/${id}`}
+          aria-label="Back to event"
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-sm font-semibold text-foreground">Attendees</h1>
+          <p className="text-xs text-muted-foreground">
+            {state === "ready" || state === "empty"
+              ? `${attendeeCount} ${attendeeCount === 1 ? "person" : "people"} responded`
+              : "Loading\u2026"}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (state === "loading") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div role="status" aria-live="polite" className="container py-6">
+          <p className="sr-only">Loading attendees</p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                data-testid="attendee-skeleton"
+                className="flex animate-pulse items-center gap-3 rounded-xl border border-border bg-card p-4"
+              >
+                <div className="h-12 w-12 rounded-full bg-secondary" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-2/3 rounded bg-secondary" />
+                  <div className="h-2 w-1/3 rounded bg-secondary" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "not-found") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <p className="text-muted-foreground">Event not found</p>
@@ -14,33 +141,76 @@ export default function Attendees() {
     );
   }
 
-  return (
-    <div className="min-h-screen bg-background">
-      <div className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-xl">
-        <div className="container flex h-16 items-center gap-4">
-          <Link to={`/events/${id}`} className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors">
-            <ArrowLeft className="h-5 w-5" />
-          </Link>
-          <div>
-            <h1 className="text-sm font-semibold text-foreground">Attendees</h1>
-            <p className="text-xs text-muted-foreground">{event.title}</p>
+  if (state === "error") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div className="container py-10">
+          <div
+            role="alert"
+            className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-destructive/30 bg-destructive/10 p-6 text-center text-destructive"
+          >
+            <AlertTriangle className="mb-2 h-6 w-6" />
+            <p className="font-semibold">Could not load attendees</p>
+            <p className="mt-1 text-sm">
+              Something went wrong talking to the server. Please refresh the
+              page or try again later.
+            </p>
           </div>
         </div>
       </div>
+    );
+  }
 
-      <div className="container py-6">
-        <p className="mb-4 text-sm text-muted-foreground">{event.attendees.length} people attending</p>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {event.attendees.map((a) => (
-            <div key={a.id} className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover">
-              <img src={a.avatar} alt={a.name} className="h-12 w-12 rounded-full object-cover" />
-              <div>
-                <p className="font-medium text-foreground">{a.name}</p>
-                <p className="text-xs text-muted-foreground">Attending</p>
-              </div>
-            </div>
-          ))}
+  if (state === "empty") {
+    return (
+      <div className="min-h-screen bg-background">
+        {header}
+        <div className="container py-10">
+          <div className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-border bg-card p-8 text-center">
+            <Users className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="font-semibold text-foreground">
+              No one has responded yet
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Be the first to RSVP and attendees will show up here.
+            </p>
+          </div>
         </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {header}
+      <div className="container py-6">
+        <p className="mb-4 text-sm text-muted-foreground">
+          {attendeeCount} {attendeeCount === 1 ? "person" : "people"} responded
+        </p>
+        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {attendees.map((a) => (
+            <li
+              key={`${a.event_id}-${a.user_id}`}
+              className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-surface-hover"
+            >
+              <div
+                aria-hidden="true"
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
+              >
+                {getInitials(a.display_name)}
+              </div>
+              <div className="min-w-0">
+                <p className="truncate font-medium text-foreground">
+                  {a.display_name || "Anonymous"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {statusLabel(a.status)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/frontend/eventconnect-web/src/test/Attendees.test.tsx
+++ b/frontend/eventconnect-web/src/test/Attendees.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Attendees from "../pages/Attendees";
@@ -169,5 +169,175 @@ describe("Attendees page", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
+  });
+
+  // ─── PR 3 polish: search filter + status chips ─────────────────────────────
+
+  const threeMixedAttendees = [
+    {
+      event_id: "evt-1",
+      user_id: 1,
+      display_name: "Sofia Chen",
+      status: "going",
+      joined_at: "2026-04-01T00:00:00Z",
+    },
+    {
+      event_id: "evt-1",
+      user_id: 2,
+      display_name: "Marcus Johnson",
+      status: "interested",
+      joined_at: "2026-04-02T00:00:00Z",
+    },
+    {
+      event_id: "evt-1",
+      user_id: 3,
+      display_name: "Ava Rodriguez",
+      status: "not_going",
+      joined_at: "2026-04-03T00:00:00Z",
+    },
+  ];
+
+  it("filters the attendee list by the search query (TC-ATT-009)", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse(threeMixedAttendees));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+
+    const input = screen.getByLabelText(/search attendees by name/i);
+    fireEvent.change(input, { target: { value: "sofia" } });
+
+    expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    expect(screen.queryByText("Marcus Johnson")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ava Rodriguez")).not.toBeInTheDocument();
+  });
+
+  it("search is case-insensitive (TC-ATT-010)", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse(threeMixedAttendees));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    });
+
+    const input = screen.getByLabelText(/search attendees by name/i);
+    fireEvent.change(input, { target: { value: "MARCUS" } });
+
+    expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    expect(screen.queryByText("Sofia Chen")).not.toBeInTheDocument();
+  });
+
+  it("status chip filters the list to a single status (TC-ATT-011)", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse(threeMixedAttendees));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("chip-interested"));
+
+    expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    expect(screen.queryByText("Sofia Chen")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ava Rodriguez")).not.toBeInTheDocument();
+    // The active chip should expose its pressed state for a11y.
+    expect(screen.getByTestId("chip-interested")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("search and chip filters compose (TC-ATT-012)", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        ...threeMixedAttendees,
+        {
+          event_id: "evt-1",
+          user_id: 4,
+          display_name: "Sofia Martinez",
+          status: "interested",
+          joined_at: "2026-04-04T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+
+    // "Interested" + "Sofia" should match only Sofia Martinez.
+    fireEvent.click(screen.getByTestId("chip-interested"));
+    fireEvent.change(
+      screen.getByLabelText(/search attendees by name/i),
+      { target: { value: "sofia" } }
+    );
+
+    expect(screen.getByText("Sofia Martinez")).toBeInTheDocument();
+    expect(screen.queryByText("Sofia Chen")).not.toBeInTheDocument(); // wrong status
+    expect(screen.queryByText("Marcus Johnson")).not.toBeInTheDocument();
+  });
+
+  it("shows the no-results card with a Clear filters button when filters exclude everyone (TC-ATT-013)", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse(threeMixedAttendees));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+
+    fireEvent.change(
+      screen.getByLabelText(/search attendees by name/i),
+      { target: { value: "zzznobody" } }
+    );
+
+    expect(screen.getByTestId("attendees-no-results")).toBeInTheDocument();
+    expect(screen.getByText(/no attendees match/i)).toBeInTheDocument();
+
+    // Clicking "Clear filters" should restore the full list without re-fetching.
+    const clearBtn = screen.getByRole("button", { name: /clear filters/i });
+    fireEvent.click(clearBtn);
+
+    expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    expect(screen.getByText("Ava Rodriguez")).toBeInTheDocument();
+    // Only the original fetch — Clear filters must not trigger another request.
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("anonymous attendees are searchable by the word 'Anonymous' (TC-ATT-014)", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        ...threeMixedAttendees,
+        {
+          event_id: "evt-1",
+          user_id: 5,
+          display_name: null,
+          status: "going",
+          joined_at: "2026-04-05T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    });
+
+    fireEvent.change(
+      screen.getByLabelText(/search attendees by name/i),
+      { target: { value: "anon" } }
+    );
+
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    expect(screen.queryByText("Sofia Chen")).not.toBeInTheDocument();
+    expect(screen.queryByText("Marcus Johnson")).not.toBeInTheDocument();
   });
 });

--- a/frontend/eventconnect-web/src/test/Attendees.test.tsx
+++ b/frontend/eventconnect-web/src/test/Attendees.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Attendees from "../pages/Attendees";
+
+// Mock global fetch, matching the pattern used in RSVPButton.test.tsx
+global.fetch = vi.fn();
+
+function renderAtEvent(eventId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${eventId}/attendees`]}>
+      <Routes>
+        <Route path="/events/:id/attendees" element={<Attendees />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const buildOkResponse = (attendees: any[], count?: number) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    event_id: "evt-1",
+    attendee_count: count ?? attendees.length,
+    attendees,
+  }),
+});
+
+describe("Attendees page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the loading skeleton while fetching", async () => {
+    // Return a slow-resolving response so we can see the loading state
+    (fetch as any).mockImplementationOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(buildOkResponse([])), 100)
+        )
+    );
+
+    renderAtEvent("evt-1");
+
+    expect(screen.getAllByTestId("attendee-skeleton").length).toBeGreaterThan(0);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders a real attendee list returned by the backend", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 1,
+          display_name: "Sofia Chen",
+          status: "going",
+          joined_at: "2026-04-01T00:00:00Z",
+        },
+        {
+          event_id: "evt-1",
+          user_id: 2,
+          display_name: "Marcus Johnson",
+          status: "interested",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Sofia Chen")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Marcus Johnson")).toBeInTheDocument();
+    expect(screen.getByText("Going")).toBeInTheDocument();
+    expect(screen.getByText("Interested")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("/events/evt-1/attendees");
+  });
+
+  it("renders initials from the display name when no avatar is returned", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 9,
+          display_name: "Aisha Patel",
+          status: "going",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Aisha Patel")).toBeInTheDocument();
+    });
+    expect(screen.getByText("AP")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Anonymous' when display_name is null", async () => {
+    (fetch as any).mockResolvedValueOnce(
+      buildOkResponse([
+        {
+          event_id: "evt-1",
+          user_id: 7,
+          display_name: null,
+          status: "going",
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ])
+    );
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the empty state when the event has no attendees", async () => {
+    (fetch as any).mockResolvedValueOnce(buildOkResponse([]));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no one has responded yet/i)
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryAllByTestId("attendee-skeleton").length).toBe(0);
+  });
+
+  it("shows a not-found state when the backend returns 404", async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "Event not found" }),
+    });
+
+    renderAtEvent("evt-missing");
+
+    await waitFor(() => {
+      expect(screen.getByText(/event not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error alert when the backend returns 500", async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Internal server error" }),
+    });
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /could not load attendees/i
+      );
+    });
+  });
+
+  it("shows an error alert when fetch rejects (network failure)", async () => {
+    (fetch as any).mockRejectedValueOnce(new Error("network down"));
+
+    renderAtEvent("evt-1");
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two new affordances to the Attendees page shipped in #32:

- **Search input** — case-insensitive substring match on the rendered
  attendee name. Anonymous rows (where `display_name` is `null`) are
  searchable by typing "anon", so the fallback row isn't a second-class
  citizen.
- **Status filter chips** — `All` / `Going` / `Interested` / `Declined`
  with live per-status counts (e.g. `Going (4)`). Active chip exposes
  `aria-pressed="true"` for screen readers.
- **Zero-match state** — if the active filter combination excludes
  everyone, the grid is swapped for a `No attendees match` card with a
  `Clear filters` button that restores defaults **without refetching**.

All filtering is client-side on the list already returned by
`GET /events/:id/attendees`. Rationale: attendee lists per event are
bounded (typically <200), already in memory after the initial fetch, and
a backend round-trip per keystroke would add a second failure mode for
an already-loaded page.

No backend changes. No new dependencies (tests use `fireEvent` rather
than pulling in `@testing-library/user-event`).

## Changes

- `frontend/eventconnect-web/src/pages/Attendees.tsx` — filter bar,
  memoized `filteredAttendees`, `statusCounts`, no-results card, clear
  filters button.
- `frontend/eventconnect-web/src/test/Attendees.test.tsx` — six new
  Vitest integration tests.

## Tests

`npx vitest run src/test/Attendees.test.tsx` — **14 passed, 0 failed**
(8 existing + 6 new). Full frontend suite: **24 passed, 0 failed**.

New cases:

| ID | Covers |
|---|---|
| TC-ATT-009 | Search filters by name |
| TC-ATT-010 | Search is case-insensitive |
| TC-ATT-011 | Status chip filters the list + `aria-pressed` toggles |
| TC-ATT-012 | Search and chip filters compose |
| TC-ATT-013 | No-match card renders + Clear filters restores without refetching |
| TC-ATT-014 | Anonymous rows are searchable by "anon" |

## Test plan

- [ ] Visit `/events/<id>/attendees` on an event with ≥3 RSVPs.
- [ ] Type a partial name into the search — list narrows live.
- [ ] Click a status chip — list filters to that status; count in chip
      matches.
- [ ] Combine chip + search — both narrow together.
- [ ] Type a nonsense query — `No attendees match` card appears; click
      `Clear filters` — full list returns, no network activity in DevTools.
- [ ] Tab through the chips — `aria-pressed` toggles correctly.

## Notes for reviewers

- Stacked on top of #32. If #32 merges first, this PR's diff will
  auto-collapse to just the two commits here.
- No schema, no controller, no route changes — CI is expected to go
  3/3 green with no workflow edits (same as #32).