### PR TITLE
feat(auth+profile): PATCH /auth/me + wire Edit Profile modal (closes BUG-S3-006)

### DIFF
--- a/backend/__tests__/auth.unit.test.js
+++ b/backend/__tests__/auth.unit.test.js
@@ -270,4 +270,125 @@ describe("Auth API (unit)", () => {
       errSpy.mockRestore();
     });
   });
+
+  // ─── PATCH /auth/me ───────────────────────────────────────────────────────
+
+  describe("PATCH /auth/me", () => {
+    test("TC-AUTH-016: returns 401 when no token is provided", async () => {
+      const res = await request(app)
+        .patch("/auth/me")
+        .send({ name: "New Name" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatch(/missing token/i);
+    });
+
+    test("TC-AUTH-017: returns 200 with updated user record on valid request", async () => {
+      pool.query.mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            user_id: 7,
+            email: "alice@test.com",
+            display_name: "Alice Renamed",
+            created_at: new Date("2026-01-15T00:00:00Z"),
+          },
+        ],
+      });
+
+      const token = jwt.sign(
+        { userId: 7, email: "alice@test.com" },
+        JWT_SECRET,
+        { expiresIn: "1h" }
+      );
+
+      const res = await request(app)
+        .patch("/auth/me")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ name: "Alice Renamed" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.user).toEqual({
+        id: 7,
+        email: "alice@test.com",
+        name: "Alice Renamed",
+        created_at: expect.any(String),
+      });
+      // Verify the SQL was parameterized with the trimmed name and the
+      // userId from the JWT — not anything from the request body.
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringMatching(/UPDATE users[\s\S]*SET display_name/),
+        ["Alice Renamed", 7]
+      );
+    });
+
+    test("TC-AUTH-018: returns 400 when name is missing or whitespace-only", async () => {
+      const token = jwt.sign(
+        { userId: 7, email: "alice@test.com" },
+        JWT_SECRET,
+        { expiresIn: "1h" }
+      );
+
+      // Missing name
+      const res1 = await request(app)
+        .patch("/auth/me")
+        .set("Authorization", `Bearer ${token}`)
+        .send({});
+      expect(res1.status).toBe(400);
+      expect(res1.body.error).toMatch(/name is required/i);
+
+      // Whitespace-only name
+      const res2 = await request(app)
+        .patch("/auth/me")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ name: "   " });
+      expect(res2.status).toBe(400);
+      expect(res2.body.error).toMatch(/cannot be empty/i);
+
+      // No DB call should have been made for either rejection.
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    test("TC-AUTH-019: returns 400 when name exceeds the length cap", async () => {
+      const token = jwt.sign(
+        { userId: 7, email: "alice@test.com" },
+        JWT_SECRET,
+        { expiresIn: "1h" }
+      );
+
+      const tooLong = "A".repeat(101);
+
+      const res = await request(app)
+        .patch("/auth/me")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ name: tooLong });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/100 characters or fewer/i);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    test("TC-AUTH-020: returns 500 when the database query fails", async () => {
+      pool.query.mockRejectedValueOnce(new Error("db down"));
+
+      const token = jwt.sign(
+        { userId: 7, email: "alice@test.com" },
+        JWT_SECRET,
+        { expiresIn: "1h" }
+      );
+
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const res = await request(app)
+        .patch("/auth/me")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ name: "Alice" });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/server error/i);
+
+      errSpy.mockRestore();
+    });
+  });
 });

--- a/backend/__tests__/auth.unit.test.js
+++ b/backend/__tests__/auth.unit.test.js
@@ -165,7 +165,29 @@ describe("Auth API (unit)", () => {
       expect(res.body.error).toMatch(/invalid token/i);
     });
 
-    test("TC-AUTH-012: returns 200 with payload for a valid token", async () => {
+    test("TC-AUTH-012: returns 200 with user record and rsvp summary for a valid token", async () => {
+      pool.query
+        // user lookup
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          rows: [
+            {
+              user_id: 7,
+              email: "alice@test.com",
+              display_name: "Alice Rivera",
+              created_at: new Date("2026-01-15T00:00:00Z"),
+            },
+          ],
+        })
+        // rsvp summary aggregation
+        .mockResolvedValueOnce({
+          rows: [
+            { status: "going", count: 4 },
+            { status: "interested", count: 2 },
+            { status: "not_going", count: 1 },
+          ],
+        });
+
       const token = jwt.sign({ userId: 7, email: "alice@test.com" }, JWT_SECRET, { expiresIn: "1h" });
 
       const res = await request(app)
@@ -175,6 +197,77 @@ describe("Auth API (unit)", () => {
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
       expect(res.body.payload.userId).toBe(7);
+      expect(res.body.user).toEqual({
+        id: 7,
+        email: "alice@test.com",
+        name: "Alice Rivera",
+        created_at: expect.any(String),
+      });
+      expect(res.body.rsvp_summary).toEqual({
+        going: 4,
+        interested: 2,
+        not_going: 1,
+      });
+    });
+
+    test("TC-AUTH-013: returns 404 when the token's user no longer exists", async () => {
+      pool.query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+      const token = jwt.sign({ userId: 999, email: "ghost@test.com" }, JWT_SECRET, { expiresIn: "1h" });
+
+      const res = await request(app)
+        .get("/auth/me")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toMatch(/user not found/i);
+    });
+
+    test("TC-AUTH-014: rsvp_summary defaults to zeros when user has no RSVPs", async () => {
+      pool.query
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          rows: [
+            {
+              user_id: 8,
+              email: "new@test.com",
+              display_name: "New User",
+              created_at: new Date("2026-04-01T00:00:00Z"),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const token = jwt.sign({ userId: 8, email: "new@test.com" }, JWT_SECRET, { expiresIn: "1h" });
+
+      const res = await request(app)
+        .get("/auth/me")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.rsvp_summary).toEqual({
+        going: 0,
+        interested: 0,
+        not_going: 0,
+      });
+    });
+
+    test("TC-AUTH-015: returns 500 when the database query fails", async () => {
+      pool.query.mockRejectedValueOnce(new Error("db down"));
+
+      const token = jwt.sign({ userId: 7, email: "alice@test.com" }, JWT_SECRET, { expiresIn: "1h" });
+
+      // silence expected console.error
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const res = await request(app)
+        .get("/auth/me")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/server error/i);
+
+      errSpy.mockRestore();
     });
   });
 });

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -174,3 +174,68 @@ exports.getMe = async (req, res) => {
     return res.status(500).json({ error: "Server error" });
   }
 };
+
+// PATCH /auth/me
+// Updates the authenticated user's display name. Closes BUG-S3-006: until
+// this endpoint existed the Edit Profile modal saved optimistically to
+// localStorage only and was overwritten on the next /auth/me fetch.
+const NAME_MAX_LENGTH = 100;
+
+exports.updateMe = async (req, res) => {
+  const auth = req.headers.authorization || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+
+  if (!token) {
+    return res.status(401).json({ error: "Missing token" });
+  }
+
+  let payload;
+  try {
+    payload = jwt.verify(token, JWT_SECRET);
+  } catch {
+    return res.status(401).json({ error: "Invalid token" });
+  }
+
+  const { name } = req.body || {};
+
+  if (typeof name !== "string") {
+    return res.status(400).json({ error: "Name is required" });
+  }
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return res.status(400).json({ error: "Name cannot be empty" });
+  }
+  if (trimmed.length > NAME_MAX_LENGTH) {
+    return res
+      .status(400)
+      .json({ error: `Name must be ${NAME_MAX_LENGTH} characters or fewer` });
+  }
+
+  try {
+    const result = await pool.query(
+      `UPDATE users
+       SET display_name = $1
+       WHERE user_id = $2
+       RETURNING user_id, email, display_name, created_at`,
+      [trimmed, payload.userId]
+    );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const userRow = result.rows[0];
+    return res.json({
+      ok: true,
+      user: {
+        id: userRow.user_id,
+        email: userRow.email,
+        name: userRow.display_name,
+        created_at: userRow.created_at,
+      },
+    });
+  } catch (err) {
+    console.error("updateMe error:", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+};

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -114,7 +114,7 @@ exports.googleCallback = (req, res) => {
   res.redirect(`http://localhost:8080/login?token=${token}&user=${encodeURIComponent(userJson)}`);
 };
 
-exports.getMe = (req, res) => {
+exports.getMe = async (req, res) => {
   const auth = req.headers.authorization || "";
   const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
 
@@ -122,10 +122,55 @@ exports.getMe = (req, res) => {
     return res.status(401).json({ error: "Missing token" });
   }
 
+  let payload;
   try {
-    const payload = jwt.verify(token, JWT_SECRET);
-    res.json({ ok: true, payload });
+    payload = jwt.verify(token, JWT_SECRET);
   } catch {
-    res.status(401).json({ error: "Invalid token" });
+    return res.status(401).json({ error: "Invalid token" });
+  }
+
+  try {
+    const userResult = await pool.query(
+      `SELECT user_id, email, display_name, created_at
+       FROM users
+       WHERE user_id = $1`,
+      [payload.userId]
+    );
+
+    if (userResult.rowCount === 0) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const userRow = userResult.rows[0];
+
+    const summaryResult = await pool.query(
+      `SELECT status, COUNT(*)::INT AS count
+       FROM event_attendees
+       WHERE user_id = $1
+       GROUP BY status`,
+      [payload.userId]
+    );
+
+    const rsvpSummary = { going: 0, interested: 0, not_going: 0 };
+    for (const row of summaryResult.rows) {
+      if (row.status in rsvpSummary) {
+        rsvpSummary[row.status] = row.count;
+      }
+    }
+
+    return res.json({
+      ok: true,
+      payload,
+      user: {
+        id: userRow.user_id,
+        email: userRow.email,
+        name: userRow.display_name,
+        created_at: userRow.created_at,
+      },
+      rsvp_summary: rsvpSummary,
+    });
+  } catch (err) {
+    console.error("getMe error:", err);
+    return res.status(500).json({ error: "Server error" });
   }
 };

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -18,7 +18,10 @@ router.get(
   authController.googleCallback
 );
 
-// Token check
+// Token check + profile fetch
 router.get("/me", authController.getMe);
+
+// Update display name on the authenticated user
+router.patch("/me", authController.updateMe);
 
 module.exports = router;

--- a/frontend/eventconnect-web/src/pages/Profile.tsx
+++ b/frontend/eventconnect-web/src/pages/Profile.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { User, Mail, Calendar, Trash2, Edit3, CheckCircle2, Star, XCircle } from "lucide-react";
+import {
+  User,
+  Mail,
+  Calendar,
+  Trash2,
+  Edit3,
+  CheckCircle2,
+  Star,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,69 +36,161 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 
-interface UserData {
-  name: string;
+interface ApiUser {
+  id: number | string;
   email: string;
-  avatar?: string;
-  joined: string;
+  name: string;
+  created_at: string;
 }
 
-const DEFAULT_USER: UserData = {
-  name: "Alex Rivera",
-  email: "alex.rivera@email.com",
-  avatar: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop",
-  joined: "January 2026",
-};
+interface RsvpSummary {
+  going: number;
+  interested: number;
+  not_going: number;
+}
 
-function getStoredUser(): UserData | null {
-  try {
-    const raw = localStorage.getItem("user");
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      return {
-        name: parsed.name || DEFAULT_USER.name,
-        email: parsed.email || DEFAULT_USER.email,
-        avatar: parsed.avatar || DEFAULT_USER.avatar,
-        joined: parsed.joined || DEFAULT_USER.joined,
-      };
-    }
-  } catch {
-    // ignore parse errors
-  }
-  // If no stored user but a token exists, use defaults
-  if (localStorage.getItem("token")) {
-    return DEFAULT_USER;
-  }
-  // Fall back to mock user for demo purposes
-  return DEFAULT_USER;
+interface MeResponse {
+  ok: boolean;
+  user: ApiUser;
+  rsvp_summary: RsvpSummary;
+}
+
+type LoadState = "loading" | "not-logged-in" | "error" | "ready";
+
+function formatJoined(isoDate: string): string {
+  if (!isoDate) return "—";
+  const d = new Date(isoDate);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
 }
 
 export default function Profile() {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const [user, setUser] = useState<UserData | null>(getStoredUser);
+
+  const [state, setState] = useState<LoadState>("loading");
+  const [user, setUser] = useState<ApiUser | null>(null);
+  const [summary, setSummary] = useState<RsvpSummary>({
+    going: 0,
+    interested: 0,
+    not_going: 0,
+  });
   const [editOpen, setEditOpen] = useState(false);
   const [editName, setEditName] = useState("");
 
-  const isLoggedIn = !!user;
+  useEffect(() => {
+    let cancelled = false;
 
-  // RSVP summary — mocked values (ready for real integration)
-  const rsvpSummary = { going: 5, interested: 3, notGoing: 1 };
+    async function loadProfile() {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        setState("not-logged-in");
+        return;
+      }
+
+      try {
+        const res = await fetch("/auth/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (res.status === 401) {
+          if (!cancelled) setState("not-logged-in");
+          return;
+        }
+
+        if (!res.ok) {
+          if (!cancelled) setState("error");
+          return;
+        }
+
+        const data: MeResponse = await res.json();
+        if (cancelled) return;
+
+        setUser(data.user);
+        setSummary(
+          data.rsvp_summary ?? { going: 0, interested: 0, not_going: 0 }
+        );
+        setState("ready");
+      } catch (err) {
+        console.error("Error loading profile:", err);
+        if (!cancelled) setState("error");
+      }
+    }
+
+    loadProfile();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totalRsvps = summary.going + summary.interested + summary.not_going;
 
   const stats = [
-    { label: "Going", count: rsvpSummary.going, icon: CheckCircle2, color: "text-[hsl(var(--success))]", bg: "bg-[hsl(var(--success))]/15" },
-    { label: "Interested", count: rsvpSummary.interested, icon: Star, color: "text-[hsl(var(--warning))]", bg: "bg-[hsl(var(--warning))]/15" },
-    { label: "Declined", count: rsvpSummary.notGoing, icon: XCircle, color: "text-destructive", bg: "bg-destructive/15" },
+    {
+      label: "Going",
+      count: summary.going,
+      icon: CheckCircle2,
+      color: "text-[hsl(var(--success))]",
+      bg: "bg-[hsl(var(--success))]/15",
+    },
+    {
+      label: "Interested",
+      count: summary.interested,
+      icon: Star,
+      color: "text-[hsl(var(--warning))]",
+      bg: "bg-[hsl(var(--warning))]/15",
+    },
+    {
+      label: "Declined",
+      count: summary.not_going,
+      icon: XCircle,
+      color: "text-destructive",
+      bg: "bg-destructive/15",
+    },
   ];
 
+  // ---------- Loading ----------
+  if (state === "loading") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="profile-loading"
+        className="min-h-screen bg-background"
+      >
+        <p className="sr-only">Loading profile</p>
+        <div className="h-32 bg-gradient-to-br from-primary/20 via-background to-background" />
+        <div className="container -mt-16 pb-12">
+          <div className="flex animate-pulse flex-col items-center sm:flex-row sm:items-end sm:gap-6">
+            <div className="h-28 w-28 rounded-2xl bg-secondary" />
+            <div className="mt-4 flex-1 space-y-2 sm:mt-0">
+              <div className="h-5 w-40 rounded bg-secondary" />
+              <div className="h-3 w-64 rounded bg-secondary" />
+            </div>
+          </div>
+          <div className="mt-8 grid grid-cols-3 gap-3 sm:gap-4">
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-24 animate-pulse rounded-xl border border-border bg-card"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // ---------- Not Logged In ----------
-  if (!isLoggedIn) {
+  if (state === "not-logged-in") {
     return (
       <div className="flex min-h-[70vh] flex-col items-center justify-center px-4">
         <div className="flex h-20 w-20 items-center justify-center rounded-full bg-secondary">
           <User className="h-10 w-10 text-muted-foreground" />
         </div>
-        <h2 className="mt-6 text-xl font-bold text-foreground">Not logged in</h2>
+        <h2 className="mt-6 text-xl font-bold text-foreground">
+          Not logged in
+        </h2>
         <p className="mt-2 max-w-xs text-center text-sm text-muted-foreground">
           You must be logged in to view your profile.
         </p>
@@ -102,52 +204,80 @@ export default function Profile() {
     );
   }
 
-  // ---------- Edit Profile ----------
+  // ---------- Error ----------
+  if (state === "error") {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container py-10">
+          <div
+            role="alert"
+            className="mx-auto flex max-w-md flex-col items-center rounded-xl border border-destructive/30 bg-destructive/10 p-6 text-center text-destructive"
+          >
+            <AlertTriangle className="mb-2 h-6 w-6" />
+            <p className="font-semibold">Could not load your profile</p>
+            <p className="mt-1 text-sm">
+              Something went wrong talking to the server. Please refresh the
+              page or try again later.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------- Ready ----------
+  if (!user) return null; // type guard — state is "ready" implies user is set
+
   const openEdit = () => {
     setEditName(user.name);
     setEditOpen(true);
   };
 
   const saveEdit = () => {
-    const updated = { ...user, name: editName.trim() || user.name };
-    setUser(updated);
+    const trimmed = editName.trim();
+    const nextName = trimmed || user.name;
+    setUser({ ...user, name: nextName });
+
+    // Optimistic localStorage update. Backend PATCH endpoint for profile
+    // edits is not implemented yet (filed as BUG-S3-006); name edits here
+    // survive until the next /auth/me response overwrites them.
     try {
-      localStorage.setItem("user", JSON.stringify(updated));
+      const raw = localStorage.getItem("user");
+      const stored = raw ? JSON.parse(raw) : {};
+      localStorage.setItem(
+        "user",
+        JSON.stringify({ ...stored, name: nextName })
+      );
     } catch {
-      // storage full — ignore
+      // storage full or parse error — ignore
     }
+
     setEditOpen(false);
-    toast({ title: "Profile updated", description: "Your name has been updated." });
+    toast({
+      title: "Profile updated",
+      description: "Your name has been updated.",
+    });
   };
 
-  // ---------- Delete Account ----------
   const handleDelete = () => {
     localStorage.removeItem("user");
     localStorage.removeItem("token");
-    toast({ title: "Account deleted", description: "You have been logged out." });
+    toast({
+      title: "Account deleted",
+      description: "You have been logged out.",
+    });
     navigate("/");
   };
 
-  // ---------- Render ----------
   return (
     <div className="min-h-screen bg-background">
-      {/* Header banner */}
       <div className="h-32 bg-gradient-to-br from-primary/20 via-background to-background" />
 
       <div className="container -mt-16 pb-12">
-        {/* Avatar + Info */}
         <div className="flex flex-col items-center sm:flex-row sm:items-end sm:gap-6">
-          {user.avatar ? (
-            <img
-              src={user.avatar}
-              alt={user.name}
-              className="h-28 w-28 rounded-2xl border-4 border-background object-cover shadow-xl"
-            />
-          ) : (
-            <div className="flex h-28 w-28 items-center justify-center rounded-2xl border-4 border-background bg-secondary shadow-xl">
-              <User className="h-12 w-12 text-muted-foreground" />
-            </div>
-          )}
+          <div className="flex h-28 w-28 items-center justify-center rounded-2xl border-4 border-background bg-secondary shadow-xl">
+            <User className="h-12 w-12 text-muted-foreground" />
+          </div>
           <div className="mt-4 text-center sm:mt-0 sm:text-left">
             <h1 className="text-2xl font-bold text-foreground">{user.name}</h1>
             <div className="mt-1 flex flex-col gap-1 text-sm text-muted-foreground sm:flex-row sm:gap-4">
@@ -155,43 +285,60 @@ export default function Profile() {
                 <Mail className="h-3.5 w-3.5" /> {user.email}
               </span>
               <span className="flex items-center justify-center gap-1.5 sm:justify-start">
-                <Calendar className="h-3.5 w-3.5" /> Joined {user.joined}
+                <Calendar className="h-3.5 w-3.5" /> Joined{" "}
+                {formatJoined(user.created_at)}
               </span>
             </div>
           </div>
         </div>
 
-        {/* RSVP Summary */}
         <div className="mt-8 grid grid-cols-3 gap-3 sm:gap-4">
           {stats.map((s) => (
-            <div key={s.label} className="rounded-xl border border-border bg-card p-4 text-center">
-              <div className={`mx-auto flex h-10 w-10 items-center justify-center rounded-full ${s.bg}`}>
+            <div
+              key={s.label}
+              className="rounded-xl border border-border bg-card p-4 text-center"
+            >
+              <div
+                className={`mx-auto flex h-10 w-10 items-center justify-center rounded-full ${s.bg}`}
+              >
                 <s.icon className={`h-5 w-5 ${s.color}`} />
               </div>
-              <p className="mt-3 text-2xl font-bold text-foreground">{s.count}</p>
+              <p className="mt-3 text-2xl font-bold text-foreground">
+                {s.count}
+              </p>
               <p className="mt-0.5 text-xs text-muted-foreground">{s.label}</p>
             </div>
           ))}
         </div>
 
-        {/* Account Summary */}
         <div className="mt-8 rounded-xl border border-border bg-card p-5">
-          <h2 className="text-sm font-semibold text-foreground">Account Summary</h2>
+          <h2 className="text-sm font-semibold text-foreground">
+            Account Summary
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            You have RSVP'd to {rsvpSummary.going + rsvpSummary.interested + rsvpSummary.notGoing} events.
-            Keep exploring to discover more happenings near you!
+            {totalRsvps === 0
+              ? "You haven't RSVP'd to any events yet. Start exploring to find your next happening!"
+              : `You have RSVP'd to ${totalRsvps} ${
+                  totalRsvps === 1 ? "event" : "events"
+                }. Keep exploring to discover more happenings near you!`}
           </p>
         </div>
 
-        {/* Actions */}
         <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-          <Button variant="outline" className="gap-2 rounded-xl" onClick={openEdit}>
+          <Button
+            variant="outline"
+            className="gap-2 rounded-xl"
+            onClick={openEdit}
+          >
             <Edit3 className="h-4 w-4" /> Edit Profile
           </Button>
 
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <Button variant="outline" className="gap-2 rounded-xl border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive">
+              <Button
+                variant="outline"
+                className="gap-2 rounded-xl border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive"
+              >
                 <Trash2 className="h-4 w-4" /> Delete Account
               </Button>
             </AlertDialogTrigger>
@@ -199,7 +346,8 @@ export default function Profile() {
               <AlertDialogHeader>
                 <AlertDialogTitle>Delete your account?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  This action cannot be undone. Your profile and RSVP history will be permanently removed.
+                  This action cannot be undone. Your profile and RSVP history
+                  will be permanently removed.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -216,12 +364,13 @@ export default function Profile() {
         </div>
       </div>
 
-      {/* Edit Profile Dialog */}
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Edit Profile</DialogTitle>
-            <DialogDescription>Update your display name below.</DialogDescription>
+            <DialogDescription>
+              Update your display name below.
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 py-2">
             <div className="space-y-1.5">

--- a/frontend/eventconnect-web/src/pages/Profile.tsx
+++ b/frontend/eventconnect-web/src/pages/Profile.tsx
@@ -77,6 +77,8 @@ export default function Profile() {
   });
   const [editOpen, setEditOpen] = useState(false);
   const [editName, setEditName] = useState("");
+  const [editSaving, setEditSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -230,33 +232,102 @@ export default function Profile() {
 
   const openEdit = () => {
     setEditName(user.name);
+    setEditError(null);
     setEditOpen(true);
   };
 
-  const saveEdit = () => {
-    const trimmed = editName.trim();
-    const nextName = trimmed || user.name;
-    setUser({ ...user, name: nextName });
+  // Saves the edited display name via PATCH /auth/me. Closes BUG-S3-006:
+  // before this PR the modal saved optimistically to localStorage only and
+  // was overwritten on the next /auth/me fetch.
+  const saveEdit = async () => {
+    if (editSaving) return;
+    setEditError(null);
 
-    // Optimistic localStorage update. Backend PATCH endpoint for profile
-    // edits is not implemented yet (filed as BUG-S3-006); name edits here
-    // survive until the next /auth/me response overwrites them.
-    try {
-      const raw = localStorage.getItem("user");
-      const stored = raw ? JSON.parse(raw) : {};
-      localStorage.setItem(
-        "user",
-        JSON.stringify({ ...stored, name: nextName })
-      );
-    } catch {
-      // storage full or parse error — ignore
+    const trimmed = editName.trim();
+    if (trimmed.length === 0) {
+      setEditError("Name cannot be empty");
+      return;
+    }
+    if (trimmed === user.name) {
+      // Nothing changed — close the modal without a request.
+      setEditOpen(false);
+      return;
     }
 
-    setEditOpen(false);
-    toast({
-      title: "Profile updated",
-      description: "Your name has been updated.",
-    });
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setEditError("Your session has expired. Please log in again.");
+      return;
+    }
+
+    setEditSaving(true);
+    try {
+      const res = await fetch("/auth/me", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name: trimmed }),
+      });
+
+      if (!res.ok) {
+        // Validation errors (400) come back with a server-side message we
+        // can surface inline; everything else gets a generic toast so the
+        // modal can stay open for the user to retry.
+        let serverMessage: string | undefined;
+        try {
+          const body = await res.json();
+          serverMessage = body?.error;
+        } catch {
+          // ignore JSON parse failures — we'll fall through to generic copy
+        }
+
+        if (res.status === 400 && serverMessage) {
+          setEditError(serverMessage);
+        } else {
+          toast({
+            title: "Couldn't save your changes",
+            description:
+              serverMessage ?? "Something went wrong. Please try again.",
+            variant: "destructive",
+          });
+        }
+        return;
+      }
+
+      const data: { ok: boolean; user: ApiUser } = await res.json();
+      setUser(data.user);
+
+      // Keep localStorage in sync so other tabs / a page reload see the
+      // updated name immediately, before the next /auth/me round-trip.
+      try {
+        const raw = localStorage.getItem("user");
+        const stored = raw ? JSON.parse(raw) : {};
+        localStorage.setItem(
+          "user",
+          JSON.stringify({ ...stored, name: data.user.name })
+        );
+      } catch {
+        // storage full or parse error — ignore
+      }
+
+      setEditOpen(false);
+      toast({
+        title: "Profile updated",
+        description: "Your name has been updated.",
+      });
+    } catch (err) {
+      console.error("Error saving profile:", err);
+      toast({
+        title: "Couldn't save your changes",
+        description:
+          "Network error. Check your connection and try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setEditSaving(false);
+    }
   };
 
   const handleDelete = () => {
@@ -364,7 +435,13 @@ export default function Profile() {
         </div>
       </div>
 
-      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+      <Dialog
+        open={editOpen}
+        onOpenChange={(open) => {
+          if (!open) setEditError(null);
+          setEditOpen(open);
+        }}
+      >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Edit Profile</DialogTitle>
@@ -378,16 +455,35 @@ export default function Profile() {
               <Input
                 id="edit-name"
                 value={editName}
-                onChange={(e) => setEditName(e.target.value)}
+                onChange={(e) => {
+                  setEditName(e.target.value);
+                  if (editError) setEditError(null);
+                }}
                 placeholder="Your name"
+                aria-invalid={editError ? true : undefined}
+                aria-describedby={editError ? "edit-name-error" : undefined}
+                disabled={editSaving}
               />
+              {editError && (
+                <p
+                  id="edit-name-error"
+                  role="alert"
+                  className="text-xs text-destructive"
+                >
+                  {editError}
+                </p>
+              )}
             </div>
           </div>
           <DialogFooter>
             <DialogClose asChild>
-              <Button variant="outline">Cancel</Button>
+              <Button variant="outline" disabled={editSaving}>
+                Cancel
+              </Button>
             </DialogClose>
-            <Button onClick={saveEdit}>Save</Button>
+            <Button onClick={saveEdit} disabled={editSaving}>
+              {editSaving ? "Saving…" : "Save"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/frontend/eventconnect-web/src/test/Profile.test.tsx
+++ b/frontend/eventconnect-web/src/test/Profile.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Profile from "../pages/Profile";
+
+// Mock global fetch, matching the pattern used in RSVPButton.test.tsx
+// and Attendees.test.tsx.
+global.fetch = vi.fn();
+
+function renderProfile() {
+  return render(
+    <MemoryRouter>
+      <Profile />
+    </MemoryRouter>
+  );
+}
+
+const buildMeResponse = (
+  overrides: Partial<{
+    user: {
+      id: number | string;
+      email: string;
+      name: string;
+      created_at: string;
+    };
+    rsvp_summary: { going: number; interested: number; not_going: number };
+  }> = {}
+) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    ok: true,
+    user: {
+      id: 1,
+      email: "alice@test.com",
+      name: "Alice Rivera",
+      created_at: "2026-01-15T00:00:00Z",
+      ...(overrides.user ?? {}),
+    },
+    rsvp_summary: overrides.rsvp_summary ?? {
+      going: 4,
+      interested: 2,
+      not_going: 1,
+    },
+  }),
+});
+
+describe("Profile page", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("shows the loading skeleton while /auth/me is in flight", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockImplementationOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(buildMeResponse()), 100)
+        )
+    );
+
+    renderProfile();
+
+    expect(screen.getByTestId("profile-loading")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders real user data returned by the backend", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce(buildMeResponse());
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Rivera")).toBeInTheDocument();
+    });
+    expect(screen.getByText("alice@test.com")).toBeInTheDocument();
+    // Locale-agnostic — just confirm the month/year were formatted in.
+    expect(screen.getByText(/Joined .*January.*2026/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/auth/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fake-token",
+        }),
+      })
+    );
+  });
+
+  it("renders real RSVP summary counts from the backend", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce(
+      buildMeResponse({
+        rsvp_summary: { going: 7, interested: 3, not_going: 2 },
+      })
+    );
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Rivera")).toBeInTheDocument();
+    });
+    expect(screen.getByText("7")).toBeInTheDocument(); // going
+    expect(screen.getByText("3")).toBeInTheDocument(); // interested
+    expect(screen.getByText("2")).toBeInTheDocument(); // declined
+    expect(screen.getByText(/RSVP'd to 12 events/)).toBeInTheDocument();
+  });
+
+  it("shows the not-logged-in state when no token is present", async () => {
+    // no token in localStorage
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText(/not logged in/i)).toBeInTheDocument();
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows the not-logged-in state when /auth/me returns 401 (stale token)", async () => {
+    localStorage.setItem("token", "expired-token");
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Invalid token" }),
+    });
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText(/not logged in/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the error alert when /auth/me returns 500", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Server error" }),
+    });
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /could not load your profile/i
+      );
+    });
+  });
+
+  it("shows the error alert when fetch rejects (network failure)", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockRejectedValueOnce(new Error("network down"));
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  it("uses friendly copy when the user has zero RSVPs", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce(
+      buildMeResponse({
+        rsvp_summary: { going: 0, interested: 0, not_going: 0 },
+      })
+    );
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Rivera")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/haven't RSVP'd to any events yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("uses singular grammar when the user has exactly 1 RSVP", async () => {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce(
+      buildMeResponse({
+        rsvp_summary: { going: 1, interested: 0, not_going: 0 },
+      })
+    );
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText(/RSVP'd to 1 event\b/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/RSVP'd to 1 events/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/eventconnect-web/src/test/Profile.test.tsx
+++ b/frontend/eventconnect-web/src/test/Profile.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Profile from "../pages/Profile";
@@ -192,5 +192,132 @@ describe("Profile page", () => {
       expect(screen.getByText(/RSVP'd to 1 event\b/)).toBeInTheDocument();
     });
     expect(screen.queryByText(/RSVP'd to 1 events/)).not.toBeInTheDocument();
+  });
+
+  // ─── PR 4: Edit Profile → PATCH /auth/me ──────────────────────────────────
+
+  // Open the Profile page in a "ready" state and then open the Edit Profile
+  // dialog. Returns nothing — assertions live in the individual tests.
+  async function loadAndOpenEditModal() {
+    localStorage.setItem("token", "fake-token");
+    (fetch as any).mockResolvedValueOnce(buildMeResponse());
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Rivera")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /edit profile/i }));
+
+    // Dialog content is portaled — wait for it to mount.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    });
+  }
+
+  it("TC-PRF-018: Edit modal opens pre-filled with the current user name", async () => {
+    await loadAndOpenEditModal();
+
+    const input = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    expect(input.value).toBe("Alice Rivera");
+  });
+
+  it("TC-PRF-019: happy path — PATCH /auth/me is called and the displayed name updates", async () => {
+    await loadAndOpenEditModal();
+
+    // Mock the PATCH response. Backend returns the updated user record so
+    // the client doesn't need a follow-up /auth/me round-trip.
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        user: {
+          id: 1,
+          email: "alice@test.com",
+          name: "Alice Renamed",
+          created_at: "2026-01-15T00:00:00Z",
+        },
+      }),
+    });
+
+    const input = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Alice Renamed" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Verify the PATCH call shape.
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/auth/me",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: expect.objectContaining({
+            Authorization: "Bearer fake-token",
+            "Content-Type": "application/json",
+          }),
+          body: JSON.stringify({ name: "Alice Renamed" }),
+        })
+      );
+    });
+
+    // The header should reflect the new name.
+    await waitFor(() => {
+      expect(screen.getByText("Alice Renamed")).toBeInTheDocument();
+    });
+    // …and the old name should be gone.
+    expect(screen.queryByText("Alice Rivera")).not.toBeInTheDocument();
+  });
+
+  it("TC-PRF-020: PATCH 400 surfaces the server message inline; modal stays open", async () => {
+    await loadAndOpenEditModal();
+
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "Name cannot be empty" }),
+    });
+
+    const input = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    // Change to a different (non-empty client-side, but server rejects) value
+    // so the client validator doesn't short-circuit before hitting fetch.
+    fireEvent.change(input, { target: { value: "X" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      // Inline error rendered with role="alert" so assistive tech announces it.
+      const alerts = screen
+        .getAllByRole("alert")
+        .map((el) => el.textContent ?? "");
+      expect(alerts.some((t) => /name cannot be empty/i.test(t))).toBe(true);
+    });
+
+    // The modal should still be open — the input is still in the document.
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    // Name in the header should NOT have changed.
+    expect(screen.getByText("Alice Rivera")).toBeInTheDocument();
+  });
+
+  it("TC-PRF-021: empty / whitespace-only input is caught client-side without firing PATCH", async () => {
+    await loadAndOpenEditModal();
+
+    const input = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+
+    // Snapshot the call count — only the initial /auth/me load should
+    // have happened.
+    const callsBeforeSave = (fetch as any).mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const alerts = screen
+        .getAllByRole("alert")
+        .map((el) => el.textContent ?? "");
+      expect(alerts.some((t) => /cannot be empty/i.test(t))).toBe(true);
+    });
+
+    // No additional fetch was made — client validation short-circuited.
+    expect((fetch as any).mock.calls.length).toBe(callsBeforeSave);
   });
 });


### PR DESCRIPTION
## Summary

Closes **BUG-S3-006** — until this PR, the Edit Profile modal saved the
new display name to React state and `localStorage` only. Any /auth/me
fetch (refresh, re-login, navigation back to Profile) overwrote the
edit. The bug was filed in #36 with a comment in `Profile.tsx` pointing
at the issue.

This PR adds the missing backend endpoint and wires the modal to it.

### Backend — new `PATCH /auth/me`

- Bearer-token auth (same JWT flow as `GET /auth/me`).
- Body: `{ name: string }`.
- Validates: name is a string, trimmed name is non-empty, trimmed name
  ≤ 100 chars. Each rule has a distinct 400 error message so the
  client can surface it inline.
- DB: `UPDATE users SET display_name = $1 WHERE user_id = $2 RETURNING
  user_id, email, display_name, created_at` — parameterized, no
  string concatenation, userId comes from the JWT (never trusted from
  the request body).
- Errors: 401 missing/invalid token, 404 user no longer exists,
  500 DB failure.

### Frontend — Edit Profile modal

- Real PATCH replaces the optimistic localStorage save.
- Save button disables and shows `Saving…` while the request is in
  flight; Cancel and the input also disable.
- 400 responses surface the server's error message inline next to the
  input (`role="alert"`, wired via `aria-describedby`); modal stays
  open so the user can correct and retry.
- 500 / network failures raise a destructive toast and keep the modal
  open.
- Empty / whitespace-only names are caught client-side and don't fire
  a request.
- On success, the new user record from the backend is stored in React
  state and mirrored to `localStorage` so a page reload doesn't flash
  the stale name before the next `/auth/me` round-trip.

### Changes

- `backend/controllers/auth.controller.js` — `exports.updateMe`.
- `backend/routes/auth.routes.js` — `router.patch("/me", …)`.
- `backend/__tests__/auth.unit.test.js` — TC-AUTH-016 → TC-AUTH-020.
- `frontend/eventconnect-web/src/pages/Profile.tsx` — `saveEdit`
  rewritten as async, new `editSaving` and `editError` state, modal
  disabled-state plumbing.
- `frontend/eventconnect-web/src/test/Profile.test.tsx` — TC-PRF-018
  → TC-PRF-021.

## Tests

| Suite | Result |
|---|---|
| `backend/__tests__/auth.unit.test.js` | **20 passed, 0 failed** (15 existing + 5 new) |
| `frontend/eventconnect-web/src/test/Profile.test.tsx` | **13 passed, 0 failed** (9 existing + 4 new) |
| Full frontend Vitest suite | **23 passed, 0 failed** |

New cases:

| ID | Covers |
|---|---|
| TC-AUTH-016 | 401 when no token is provided |
| TC-AUTH-017 | 200 happy path; SQL parameterized correctly |
| TC-AUTH-018 | 400 missing or whitespace-only name; no DB call |
| TC-AUTH-019 | 400 over-length name; no DB call |
| TC-AUTH-020 | 500 when DB query fails |
| TC-PRF-018 | Edit modal opens pre-filled with current name |
| TC-PRF-019 | Happy path — PATCH called, header updates, modal closes |
| TC-PRF-020 | 400 surfaces inline; modal stays open; header unchanged |
| TC-PRF-021 | Whitespace-only name caught client-side, no PATCH fires |

## Test plan

- [ ] Log in, open Profile, click `Edit Profile`. Modal opens with
      your current name pre-filled.
- [ ] Change the name, click `Save`. Button shows `Saving…` briefly,
      modal closes, header updates.
- [ ] Refresh the page (or log out and back in). Updated name persists
      — no longer reverts.
- [ ] Reopen modal, clear the input, click `Save`. Inline error
      `Name cannot be empty` shown; modal stays open.
- [ ] Clear localStorage `token`, click `Save`. Inline error about
      session expiry shown.
- [ ] Stop the backend, retry `Save` with a valid name. Destructive
      toast shown, modal stays open.

## Notes for reviewers

- Stacked on top of #36 (PR 2). If #36 merges first, this PR's diff
  collapses to just the two commits here.
- No new dependencies. No schema migration — uses the existing
  `display_name` column on `users`.
- `email` is intentionally **not** mutable here. Tracked separately
  if/when we want it.
- BUG-S3-006 reference comment in `Profile.tsx` was removed since the
  PATCH endpoint now exists.